### PR TITLE
Update bower.json - removed requirejs dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,7 @@
     "format"
   ],
   "dependencies": {
-    "angular": "1.2.16",
-    "requirejs": "~2.1.16"
+    "angular": "1.2.16"
   },
   "devDependencies": {
     "angular-mocks": "1.2.16"


### PR DESCRIPTION
It appears requirejs is only used in the demo and it causes errors when ng-prettyjson is used in angular apps not using require.