### PR TITLE
Add package informations to bower.json and package.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "ng-prettyjson",
   "description": "AngularJS directive for json pretty output (colors and indent)",
   "version": "0.1.8",
+  "license": "MIT",
   "author": {
     "name": "Julien Valéry",
     "email": "darul75@gmail.com"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ng-prettyjson",
   "description": "AngularJS directive for json pretty output (colors / indent / editor)",
   "version": "0.1.8",
+  "license": "MIT",
   "author": {
     "name": "Julien Valéry",
     "email": "darul75@gmail.com"


### PR DESCRIPTION
Hi Julien,

we are using your library in a project, where we need to publish all the license informations. The informations are createad automatically. But the tool needs to have the data available in package.json or bower.json.

It would be cool to have it in upstream.

Thank you for the library.